### PR TITLE
Explicitly mark strings as html_safe

### DIFF
--- a/lib/mixpanel/middleware.rb
+++ b/lib/mixpanel/middleware.rb
@@ -53,7 +53,7 @@ module Mixpanel
           unless insert_at.nil?
             part.insert(insert_at, render_event_tracking_scripts) unless queue.empty?
             if @options[:insert_mixpanel_scripts]
-              part.insert(insert_at, render_mixpanel_scripts) #This will insert the mixpanel initialization code before the queue of tracking events.
+              part.insert(insert_at, render_mixpanel_scripts.html_safe) #This will insert the mixpanel initialization code before the queue of tracking events.
             end
           end
         elsif is_turbolink_request? && is_html_response?
@@ -153,11 +153,11 @@ module Mixpanel
       request = ActionDispatch::Request.new @env
 
       if include_script_tag && request.content_security_policy_nonce.present?
-        "<script type='text/javascript' nonce='#{request.content_security_policy_nonce}'>#{output}</script>"
+        "<script type='text/javascript' nonce='#{request.content_security_policy_nonce}'>#{output}</script>".html_safe
       elsif include_script_tag
-        "<script type='text/javascript'>#{output}</script>"
+        "<script type='text/javascript'>#{output}</script>".html_safe
       else
-        output
+        output.html_safe
       end
     end
   end


### PR DESCRIPTION
While working on the Rails 6.1 upgrade in One, I ran into this:

![image](https://user-images.githubusercontent.com/504741/184141274-484e45cd-f72d-4188-9c94-f09460d206c4.png)

This is due to [the change](https://github.com/rails/rails/commit/147f207a57a03fc7a52040aa1f6878cf70ee0db7#diff-e88313d0bd0521e19c5940826493d699f5eec7bb2cbc1bb6dd4ab3d708a02f36R192) that if the `value` passed to `ActiveSupport::SafeBuffer#insert` is not `html_safe?` then any [html is escaped](https://github.com/rails/rails/blob/e8f189b1cb85e080525553ebf6544fecc918d87c/activesupport/lib/active_support/core_ext/string/output_safety.rb#L327-L348). This results in the script not being rendered as such but as a string.

In this PR i'm marking all the html tags we insert as `html_safe` which resolves the issue.

Drive-by fix: remove the call to `has_rdoc` in the Gemspec because this is deprecated:
```
one|master⚡ ⇒ bi
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Installing bootboot 0.1.2
Using bundler 2.2.27
Fetching https://github.com/Springest/mixpanel.git
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#has_rdoc= called from /Users/iriskuipers/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/bundler/gems/mixpanel-13e6470261e6/mixpanel.gemspec:16.

``` 

Task in Jira: https://studytube.atlassian.net/browse/SLR-397